### PR TITLE
fix: audio not playing in iOS Safari

### DIFF
--- a/instant-sounds.js
+++ b/instant-sounds.js
@@ -111,6 +111,7 @@ const InstantSounds=(function(){
 			this.audio.addEventListener('canplaythrough', _onLoadAudio);
 			this.audio.addEventListener('error', _onErrorAudio);
 			this.audio.addEventListener('ended', _onFinishedAudio);
+			this.audio.load();
 		}
 	}
 


### PR DESCRIPTION
When opening the application in iOS Safari, sounds either play only after multiple attempts or fail to play entirely. I could only reproduce the issue in the iOS version (not on desktop). Similarly to what is suggested [here](https://stackoverflow.com/questions/49792768/js-html5-audio-why-is-canplaythrough-not-fired-on-ios-safari), the load method needs to be called so the event `canplaythrough` is eventually fired.